### PR TITLE
demonstrate fixing warning with inline if statement

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,25 +15,16 @@ fn main() {
     let first_verb: &str = VERBS.choose(&mut rand::thread_rng()).unwrap();
     let second_noun: &str = NOUNS.choose(&mut rand::thread_rng()).unwrap();
 
-    // BUG: I don't know how to fix this compiler warning for line 25:
-    //
-    // warning: value assigned to `indefinite_article` is never read
-    // note: `#[warn(unused_assignments)]` on by default
-    // help: maybe it is overwritten before being read?
-    //
-    // If you know how to fix this, please create a branch on the GitHub repo with the fix.
-    let mut indefinite_article: &str = "";
-
-    if second_noun.split_at(1).0 == "a"
+    let indefinite_article = if second_noun.split_at(1).0 == "a"
         || second_noun.split_at(1).0 == "e"
         || second_noun.split_at(1).0 == "i"
         || second_noun.split_at(1).0 == "o"
         || second_noun.split_at(1).0 == "u"
     {
-        indefinite_article = "an";
+        "an"
     } else {
-        indefinite_article = "a";
-    }
+        "a"
+    };
 
     println!(
         "The {} {} {} {} {}.",


### PR DESCRIPTION
This is how you can fix the warning!

The warning basically happens because you assign `""` to the `str`, but then overwrite the `""` with either `"a"` or `"an"` later on. Which obviously that's what you intended to do anyway, and you can get rid of the warning by writing `#[allow(unused_assignments)]` before the main function. But the way i did it is more idiomatic rust, and also makes it slightly more efficient because the program only assigns once to the variable, instead of twice as in urs. 