### PR TITLE
Fix the warning about the value being written before it was read

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Rachael Ava"]
 edition = "2021"
 description = "A silly program written in Rust to output nonsensical sentences in the command line interface."
 license = "MIT"
-license-file = "LICENSE"
 keywords = ["nonsense", "generator", "novelty", "funny"]
 categories = ["command-line-utilities"]
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
     // help: maybe it is overwritten before being read?
     //
     // If you know how to fix this, please create a branch on the GitHub repo with the fix.
-    let mut indefinite_article: &str = "";
+    let indefinite_article: &str;
 
     if second_noun.split_at(1).0 == "a"
         || second_noun.split_at(1).0 == "e"


### PR DESCRIPTION
I also dropped the license-file argument from the Cargo.toml since license and license-file should not be used together. license-file is only used if there is not a valid SPDX identifier for your license. 